### PR TITLE
Allow custom colors in the coloring app

### DIFF
--- a/videocall/color/bot.cpp
+++ b/videocall/color/bot.cpp
@@ -3,6 +3,7 @@
 #include <IrcCommand>
 #include <QCoreApplication>
 #include <QTimer>
+#include <QColor>
 
 bot::bot(QObject* parent) : IrcConnection(parent)
 {
@@ -32,6 +33,26 @@ void bot::processMessage(IrcPrivateMessage* message)
 				space = hash(message->nick().toLatin1().data());
 			}
 			emit trigger_color(color, space);
+			return;
+		}
+	}
+	if (pieces[0].at(0).unicode() == 35 && pieces[0].length() == 7) {   // 35 (U+23) = "#"
+		bool rvalid, gvalid, bvalid;
+		auto color = QColor(
+			pieces[0].mid(1, 2).toInt(&rvalid, 16),
+			pieces[0].mid(3, 2).toInt(&gvalid, 16),
+			pieces[0].mid(5, 2).toInt(&bvalid, 16)
+		);
+		if (rvalid && gvalid && bvalid) {
+			bool valid = false;
+			unsigned int space = 0;
+			if(pieces.count() > 1){
+				space = pieces[1].toInt(&valid);
+			}
+			if(!valid){
+				space = hash(message->nick().toLatin1().data());
+			}
+			emit trigger_color(color.name(), space);
 			return;
 		}
 	}

--- a/videocall/color/draw_area.cpp
+++ b/videocall/color/draw_area.cpp
@@ -324,7 +324,13 @@ draw_area::draw_area(QWidget *parent) : QWidget(parent)
 
 void draw_area::register_color(QString color, unsigned int space)
 {
-	QColor color_rgb = colors[color.toLower()];
+	QColor color_rgb;
+	if (color.at(0).unicode() == 35) {   // "#"
+		color_rgb = QColor(color);
+	}
+	else {
+		color_rgb = colors[color.toLower()];
+	}
 	if(!color_rgb.isValid() || !(color_rgb.rgb() & 0xFFFFFF)){
 		return;
 	}


### PR DESCRIPTION
Completely custom colors can now be painted with the coloring app in addition to the standard named colors. Doing "#00ff00 1" will color area 1 green, for example.

This has been tested to the best of my ability and everything appears to work fine; I'm not regularly a Qt coder, however!